### PR TITLE
Basic implementation of step 1 - READY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 elm-stuff/
+index.html

--- a/elm-package.json
+++ b/elm-package.json
@@ -9,7 +9,8 @@
     "exposed-modules": [],
     "dependencies": {
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "turboMaCk/lazy-tree-with-zipper": "2.0.0 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Data/AudienceFolder.elm
+++ b/src/Data/AudienceFolder.elm
@@ -1,4 +1,10 @@
-module Data.AudienceFolder exposing (AudienceFolder, audienceFoldersJSON)
+module Data.AudienceFolder
+    exposing
+        ( AudienceFolder
+        , audienceFolders
+        , audienceFoldersDecoder
+        , audienceFoldersJSON
+        )
 
 {-| Data.AudienceFolder module
 
@@ -7,6 +13,9 @@ This module implements everything related to audience folder resource.
 # Interface
 @docs AudienceFolder, audienceFoldersJSON
 -}
+
+import Json.Decode as Decode exposing (Decoder)
+
 
 -- Type definition
 
@@ -18,6 +27,25 @@ type alias AudienceFolder =
     , name : String
     , parent : Maybe Int
     }
+
+
+audienceFolderDecoder : Decoder AudienceFolder
+audienceFolderDecoder =
+    Decode.map3 AudienceFolder
+        (Decode.field "id" Decode.int)
+        (Decode.field "name" Decode.string)
+        (Decode.field "parent" <| Decode.nullable Decode.int)
+
+
+audienceFoldersDecoder : Decoder (List AudienceFolder)
+audienceFoldersDecoder =
+    Decode.field "data" <| Decode.list audienceFolderDecoder
+
+
+audienceFolders : List AudienceFolder
+audienceFolders =
+    Decode.decodeString audienceFoldersDecoder audienceFoldersJSON
+        |> Result.withDefault []
 
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,16 +1,102 @@
 module Main exposing (main)
 
-import Html exposing (Html)
-
-
 -- Import Modules
 
-import Data.Audience
-import Data.AudienceFolder
+import Data.Audience exposing (audiences)
+import Data.AudienceFolder exposing (audienceFolders)
+import Html exposing (Attribute, Html, text)
+import Html.Attributes exposing (style)
+import Html.Events exposing (onClick)
+import Lazy.Tree.Zipper as Zipper exposing (Zipper)
+import NavTree exposing (TreeItem, isFolderWithId)
 
 
 {-| Main file of application
 -}
-main : Html msg
+main : Program Never Model Msg
 main =
-    Html.text "There will be app soon!"
+    Html.beginnerProgram
+        { model = model
+        , view = view
+        , update = update
+        }
+
+
+model : Model
+model =
+    NavTree.build audienceFolders audiences
+        |> Zipper.fromTree
+
+
+type Msg
+    = GoUp
+    | OpenFolder Int
+
+
+type alias Model =
+    Zipper TreeItem
+
+
+update : Msg -> Model -> Model
+update msg zipper =
+    case msg of
+        GoUp ->
+            Zipper.up zipper
+                -- Nothing means we're already at the root, OK to stay there
+                |> Maybe.withDefault zipper
+
+        OpenFolder folderId ->
+            Zipper.open (isFolderWithId folderId) zipper
+                |> Maybe.withDefault zipper
+
+
+view : Model -> Html Msg
+view model =
+    let
+        openedFolderItems =
+            NavTree.sortItems <| Zipper.children model
+
+        perhapsEmptyFolder =
+            if List.isEmpty openedFolderItems then
+                [ navigationItem "This folder is empty" "lightgray" [] ]
+            else
+                []
+
+        goUpButtonIfNotAtRoot =
+            if Zipper.isRoot model then
+                []
+            else
+                [ navigationItem "⇦ Go Up" "gray" [ onClick GoUp ] ]
+    in
+    Html.ul [ style [ ( "font-family", "sans-serif" ) ] ]
+        (goUpButtonIfNotAtRoot
+            ++ List.map viewItem openedFolderItems
+            ++ perhapsEmptyFolder
+        )
+
+
+viewItem : TreeItem -> Html Msg
+viewItem =
+    NavTree.withTreeItem
+        (\audienceFolder -> navigationItem ("🗀 " ++ audienceFolder.name) "#3a6187" [ onClick (OpenFolder audienceFolder.id) ])
+        (\audience -> navigationItem audience.name "#1db6e5" [])
+
+
+navigationItem : String -> String -> List (Attribute Msg) -> Html Msg
+navigationItem label bgcolor additionalAttributes =
+    Html.li
+        (style
+            -- Using inline style to make the implementation easy to run
+            -- normally this would be factored out to external CSS file; alternatively elm-css could be used
+            [ ( "background-color", bgcolor )
+            , ( "color", "white" )
+            , ( "margin", "5px" )
+            , ( "width", "200px" )
+            , ( "padding", "15px" )
+            , ( "border-radius", "5px" )
+            , ( "text-overflow", "ellipsis" )
+            , ( "overflow", "hidden" )
+            ]
+            :: additionalAttributes
+        )
+        [ text label ]

--- a/src/NavTree.elm
+++ b/src/NavTree.elm
@@ -1,0 +1,113 @@
+module NavTree
+    exposing
+        ( TreeItem
+        , build
+        , isFolderWithId
+        , sortItems
+        , withTreeItem
+        )
+
+import Data.Audience exposing (Audience)
+import Data.AudienceFolder exposing (AudienceFolder)
+import Lazy.Tree as LT exposing (Tree)
+
+
+type alias NavigationTree =
+    Tree TreeItem
+
+
+{-| Opaque type to enable having folders and items in a single navigation tree
+-}
+type TreeItem
+    = Folder AudienceFolder
+    | Leaf Audience
+
+
+{-| Catamorphism used to avoid exposing TreeItem constructors outside of this module.
+-}
+withTreeItem : (AudienceFolder -> r) -> (Audience -> r) -> TreeItem -> r
+withTreeItem audienceFolderCallback audienceCallback treeItem =
+    case treeItem of
+        Folder audienceFolder ->
+            audienceFolderCallback audienceFolder
+
+        Leaf audience ->
+            audienceCallback audience
+
+
+parentId : TreeItem -> Maybe Int
+parentId =
+    withTreeItem .parent .folder
+
+
+isFolderWithId : Int -> TreeItem -> Bool
+isFolderWithId id =
+    withTreeItem
+        (\folder -> folder.id == id)
+        (always False)
+
+
+build : List AudienceFolder -> List Audience -> NavigationTree
+build audienceFolders audiences =
+    let
+        folderItems =
+            List.map Folder audienceFolders
+
+        leafItems =
+            List.map Leaf audiences
+
+        isParent : Maybe TreeItem -> TreeItem -> Bool
+        isParent maybeParent item =
+            case maybeParent of
+                Nothing ->
+                    parentId item == Nothing
+
+                Just (Leaf _) ->
+                    -- Leaf can't be parent on ahother node. If this gets executed it means we're getting invalid data from the backend
+                    -- and should follow up with the backend team :-)
+                    Debug.log "Invalid Data received from the backend. There was an Audience which referenced another Audience as parent" False
+
+                Just (Folder audienceFolder) ->
+                    parentId item == Just audienceFolder.id
+    in
+    LT.Tree root <| LT.fromList isParent <| folderItems ++ leafItems
+
+
+
+-- To construct a zipper for our model we need a Tree
+-- But Lazy.Tree.fromList constructs a Forest, so use this dummy root to make complete tree
+
+
+root : TreeItem
+root =
+    Folder
+        -- ASSUMPTION: all nodes from the backend have positive IDs.
+        -- If this wasn't the case (check with backend team)
+        -- we could find a minimal ID in all the nodes and set the root ID to "min - 1"
+        { id = -1
+        , name = "ROOT"
+        , parent = Nothing
+        }
+
+
+sortItems : List TreeItem -> List TreeItem
+sortItems =
+    List.sortWith itemComparator
+
+
+{-| Sort all folders before leaves and within these groups use alphabetic order
+-}
+itemComparator : TreeItem -> TreeItem -> Order
+itemComparator i1 i2 =
+    case ( i1, i2 ) of
+        ( Folder f1, Folder f2 ) ->
+            compare f1.name f2.name
+
+        ( Leaf l1, Leaf l2 ) ->
+            compare l1.name l2.name
+
+        ( Folder _, Leaf _ ) ->
+            LT
+
+        ( Leaf _, Folder _ ) ->
+            GT


### PR DESCRIPTION
Hello @turboMaCk,
Here's my first attempt at implementation. I consider this READY for review.

How to run this:
1. `elm make src/Main.elm`
2. Open the generated index.html in the browser

I tried to keep the implementation simple (no external HTML, CSS and minimal dependencies) while still implementing all the requirements.

> How to make JSON parsing scalable? Do you know about applicatives?

Yes I know applicatives :-)
Among other things they're useful when there's more than 8 fields to decode in an object.
But in this case it wasn't necessary, because we needed to decode 3/4 fields, which is
easily handled using just `Json.Decode.mapN` from the `core` package.

> Is there any clever transformation of data that can be used as input of browser itself?

I transformed the flat lists of `AudienceFolder`s and `Audience`s by building a navigation tree out of it and then wrapping it into a zipper. Details below..

> What data-structures can be helpful if any?
> Do you prefer working with RoseTree or List? Why? (you can leave comment in your code)

I think the tree zipper data structure is ideal for this use case.
Although the amount of data provided in the fixtures could be easily handled using plain `List` or rose trees, I wanted to try using `Zipper`.
This made the initial construction of the navigation tree a bit harder, but should have the advantage of good performance even with large data. It also makes the implementation of the navigation simple and elegant (using only single call to `up`, `open`, `children` and `isRoot` respectively from the `Lazy.Tree.Zipper`).
I'm aware of one problem with this implementation: the library (lazy-tree-with-zipper)[https://package.elm-lang.org/packages/turboMaCk/lazy-tree-with-zipper/] I for this is using functions to achieve laziness of the data structure. This could cause [potential problems when debugging](https://groups.google.com/forum/#!topic/elm-discuss/bOAHwSnklLc) (as the debugger can't serialize the zipper state) and goes against the general recommendation "Keep the functions out of your model" .

> Which parts can be decoupled for possible re-use?
> Do you like to put those in separate module? Why yes or no?

I chose to move the navigation tree implementation into separate module and made `TreeItem` into opaque type to hide the implementation from other modules. Apart from reuse, the most common reasons for hiding implementation details is prevent clients from depending on them (thus enabling possible change of implementation in the future) and making the module API simpler (not exposing unnecessary details).